### PR TITLE
fix(vercel): disable auto deployments for not needed branches

### DIFF
--- a/scripts/pre-deployment-vercel-check.sh
+++ b/scripts/pre-deployment-vercel-check.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+# Array of allowed branch names
+allowed_branches=("main" "dev")
+
+# Get the current branch name
+current_branch=$(git rev-parse --abbrev-ref HEAD)
+
+# Check if the current branch is in the allowed branches array
+if [[ ! " ${allowed_branches[@]} " =~ " $current_branch " ]]; then
+  echo "Error: Deployment allowed only on specific branches. Current branch: $current_branch"
+  exit 0
+else
+  echo "Deployment allowed for branch $current_branch. Proceeding with deployment."
+  exit 1
+fi


### PR DESCRIPTION
Previously, auto deployments were happening for each branch, which could lead to waste of deployment computation power.