### PR TITLE
fix(vercel): auto deployments disabled for all branches

### DIFF
--- a/scripts/pre-deployment-vercel-check.sh
+++ b/scripts/pre-deployment-vercel-check.sh
@@ -6,6 +6,8 @@ allowed_branches=("main" "dev")
 # Get the current branch name
 current_branch=$(git rev-parse --abbrev-ref HEAD)
 
+env
+
 # Check if the current branch is in the allowed branches array
 if [[ ! " ${allowed_branches[@]} " =~ " $current_branch " ]]; then
   echo "Error: Deployment allowed only on specific branches. Current branch: $current_branch"

--- a/scripts/pre-deployment-vercel-check.sh
+++ b/scripts/pre-deployment-vercel-check.sh
@@ -4,9 +4,7 @@
 allowed_branches=("main" "dev")
 
 # Get the current branch name
-current_branch=$(git rev-parse --abbrev-ref HEAD)
-
-env
+current_branch=$VERCEL_GIT_COMMIT_REF
 
 # Check if the current branch is in the allowed branches array
 if [[ ! " ${allowed_branches[@]} " =~ " $current_branch " ]]; then


### PR DESCRIPTION
In #16, i tried to implement a fix that disables auto deployment for other branches then `main` and `dev`. Unfortunately, the command used there,

https://github.com/henil0604/chatpat/blob/03ac714ecfed65f8c95dc7c9424a5cc19c208154/scripts/pre-deployment-vercel-check.sh#L6-L7

to fetch current branch was fetching `master` everytime. This was because of the behaviour of the vercel deployment pipeline. However, vercel populates `VERCEL_GIT_COMMIT_REF` environment variables that is the actual branch name. So as a fix, i have updates the file and using `VERCEL_GIT_COMMIT_REF` instead.