### PR TITLE
fix: logic guards in completeUserProfile mutation route

### DIFF
--- a/src/lib/const/index.ts
+++ b/src/lib/const/index.ts
@@ -29,7 +29,7 @@ export const Pages: {
 	}
 };
 
-export const ResponseCodes = ['INVALID_INPUT', 'DONE', 'EMPTY_INPUT', 'ERROR', 'DATABASE_QUERY_ERROR'] as const;
+export const ResponseCodes = ['INVALID_INPUT', 'DONE', 'EMPTY_INPUT', 'ERROR', 'DATABASE_QUERY_ERROR', 'FORBIDDEN'] as const;
 
 export const DefaultTRPCResponseSchema = z.object({
 	error: z.boolean(),

--- a/src/lib/server/utils/isUsernameAvailable.ts
+++ b/src/lib/server/utils/isUsernameAvailable.ts
@@ -1,0 +1,28 @@
+/*
+    This utility checks if the given username is already assigned to a user
+*/
+
+import { db } from "$lib/server/db";
+import { LogType, logger } from "$lib/server/modules/log";
+
+export async function isUsernameAvailable(username: string) {
+    // get the user
+    const user = await db.user.findFirst({
+        where: {
+            username: username
+        },
+        select: {
+            // only the id for less data transfer
+            id: true
+        }
+    }).catch(error => {
+        logger()
+            .prefix("isUsernameAvailable")
+            .prefix("db")
+            .type(LogType.ERROR)
+            .message("user fetch failed", error)
+            .commit();
+    })
+
+    return user ? false : true;
+}


### PR DESCRIPTION
i implemented logic guards in `completeUserProfile` mutation to check the followings:

- if user has already completed profile
- if username is already assigned to another user