### PR TITLE
refactor: use Context API (Svelte) in NotificationDrawer Components

### DIFF
--- a/src/lib/components/IncomingFriendRequest.NotificationItem.svelte
+++ b/src/lib/components/IncomingFriendRequest.NotificationItem.svelte
@@ -4,16 +4,19 @@
 	import { Skeleton } from '$lib/components/ui/skeleton';
 	import { Button } from '$lib/components/ui/button';
 	import moment from 'moment';
-	import type { MetaNotification } from '$lib/components/NotificationDrawer.svelte';
+	import type {
+		ContextType as NotificationDrawerContextType,
+		MetaNotification
+	} from '$lib/components/NotificationDrawer.svelte';
 	import { loadingAction } from 'svelte-legos';
 	import { trpc } from '$lib/trpc/client';
 	import { toast } from 'svelte-sonner';
-	import { createEventDispatcher } from 'svelte';
+	import { createEventDispatcher, getContext, onMount } from 'svelte';
 	import { getFriendRequestInfoById } from '$lib/utils/getFriendRequestInfoById';
 
+	export let notificationId: string;
 	export let userId: string;
 	export let friendRequestId: string;
-	export let notification: MetaNotification;
 	export let wrapperElement: HTMLDivElement | void;
 
 	$: userPromise = getBasicUserInfoById(userId);
@@ -40,6 +43,7 @@
 
 		loading = false;
 		eventDispatcher('acceptFriendRequest');
+		refetch();
 	}
 
 	async function handleRejectFriendRequest() {
@@ -68,10 +72,14 @@
 	}
 
 	$: mergedPromise = Promise.all([userPromise, friendRequestPromise]);
+
+	$: notification =
+		getContext<NotificationDrawerContextType['notifications.getById']>('notifications.getById')(
+			notificationId
+		)!;
 </script>
 
 {#await mergedPromise}
-	<!--  -->
 	<div class="flex flex-row gap-3 px-5 py-2">
 		<div>
 			<Skeleton class="h-12 w-12 rounded-full border bg-gray-400" />

--- a/src/lib/components/IncomingFriendRequest.NotificationItem.svelte
+++ b/src/lib/components/IncomingFriendRequest.NotificationItem.svelte
@@ -6,7 +6,6 @@
 	import moment from 'moment';
 	import type {
 		ContextType as NotificationDrawerContextType,
-		MetaNotification
 	} from '$lib/components/NotificationDrawer.svelte';
 	import { loadingAction } from 'svelte-legos';
 	import { trpc } from '$lib/trpc/client';

--- a/src/lib/components/OutgoingFriendRequestAccepted.NotificationItem.svelte
+++ b/src/lib/components/OutgoingFriendRequestAccepted.NotificationItem.svelte
@@ -2,15 +2,23 @@
 	import { getBasicUserInfoById } from '$lib/utils/getBasicUserInfoById';
 	import Avatar from '$lib/components/Avatar.svelte';
 	import { Skeleton } from '$lib/components/ui/skeleton';
-	import { Button } from '$lib/components/ui/button';
 	import moment from 'moment';
-	import type { MetaNotification } from '$lib/components/NotificationDrawer.svelte';
+	import type {
+		ContextType as NotificationDrawerContextType,
+		MetaNotification
+	} from '$lib/components/NotificationDrawer.svelte';
 	import { loadingAction } from 'svelte-legos';
+	import { getContext } from 'svelte';
 
 	export let userId: string;
-	export let notification: MetaNotification;
+	export let notificationId: string;
 	let userPromise = getBasicUserInfoById(userId);
 	let loading = false;
+
+	$: notification =
+		getContext<NotificationDrawerContextType['notifications.getById']>('notifications.getById')(
+			notificationId
+		)!;
 </script>
 
 {#await userPromise}

--- a/src/lib/components/OutgoingFriendRequestAccepted.NotificationItem.svelte
+++ b/src/lib/components/OutgoingFriendRequestAccepted.NotificationItem.svelte
@@ -5,7 +5,6 @@
 	import moment from 'moment';
 	import type {
 		ContextType as NotificationDrawerContextType,
-		MetaNotification
 	} from '$lib/components/NotificationDrawer.svelte';
 	import { loadingAction } from 'svelte-legos';
 	import { getContext } from 'svelte';

--- a/src/lib/components/OutgoingFriendRequestRejected.NotificationItem.svelte
+++ b/src/lib/components/OutgoingFriendRequestRejected.NotificationItem.svelte
@@ -5,7 +5,6 @@
 	import moment from 'moment';
 	import type {
 		ContextType as NotificationDrawerContextType,
-		MetaNotification
 	} from '$lib/components/NotificationDrawer.svelte';
 	import { loadingAction } from 'svelte-legos';
 	import { getContext } from 'svelte';

--- a/src/lib/components/OutgoingFriendRequestRejected.NotificationItem.svelte
+++ b/src/lib/components/OutgoingFriendRequestRejected.NotificationItem.svelte
@@ -3,14 +3,23 @@
 	import Avatar from '$lib/components/Avatar.svelte';
 	import { Skeleton } from '$lib/components/ui/skeleton';
 	import moment from 'moment';
-	import type { MetaNotification } from '$lib/components/NotificationDrawer.svelte';
+	import type {
+		ContextType as NotificationDrawerContextType,
+		MetaNotification
+	} from '$lib/components/NotificationDrawer.svelte';
 	import { loadingAction } from 'svelte-legos';
+	import { getContext } from 'svelte';
 
 	export let userId: string;
-	export let notification: MetaNotification;
+	export let notificationId: string;
 
 	let userPromise = getBasicUserInfoById(userId);
 	let loading = false;
+
+	$: notification =
+		getContext<NotificationDrawerContextType['notifications.getById']>('notifications.getById')(
+			notificationId
+		)!;
 </script>
 
 {#await userPromise}

--- a/src/lib/server/trpc/routers/user.ts
+++ b/src/lib/server/trpc/routers/user.ts
@@ -356,6 +356,16 @@ export const userRouter = t.router({
                     orderBy: {
                         createdAt: 'desc',
                     },
+                    include: {
+                        user: {
+                            select: {
+                                id: true,
+                                username: true,
+                                image: true,
+                                name: true,
+                            }
+                        }
+                    },
                     take: -input.limit,
                 })
 


### PR DESCRIPTION
previously, notification object was getting passed to child components. I have refactored the components to use [ContextAPI](https://learn.svelte.dev/tutorial/context-api) from svelte to set notifications array in context of child components. This removes complexity of passing objects to child components.